### PR TITLE
Add floppy bird as a test image.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@ Sources
 -
 
 - KolibriOS: http://kolibrios.org/en/download
+- Floppy Bird: https://github.com/icebreaker/floppybird
 - FreeDOS: http://www.freedos.org/
 - FreeDos software: http://www.freedos.org/software/ and http://www.pouet.net/prodlist.php
 - Linux:


### PR DESCRIPTION
Floppy bird is an MIT-licensed Flappy Bird clone written in 16-bit assembly (bare metal) and works quite well with v86. https://github.com/icebreaker/floppybird

It presented a decent demo for this.